### PR TITLE
Added registerDistantPeripheral

### DIFF
--- a/gui.lua
+++ b/gui.lua
@@ -102,6 +102,10 @@ function registerPeripheral(side)
 	wyvernsPeripherals[peripheral.getType(side)] = peripheral.wrap(side)
 end
 
+function registerDistantPeripheral(name)
+	wyvernsPeripherals[peripheral.getType(name)] = peripheral.wrap(name)
+end
+
 function loadPeripheral(peripheralType)
 	return wyvernsPeripherals[peripheralType]
 end


### PR DESCRIPTION
Since modem have been added, you need to be able to register a distant peripheral through its name.